### PR TITLE
Ingress update for 1.19

### DIFF
--- a/APIM/Helmchart/amplify-apim-7.7/templates/anm/anm-ingress.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/templates/anm/anm-ingress.yaml
@@ -42,7 +42,7 @@ spec:
     secretName: anm-ingress-cert
     {{- end }}
   rules:
-  - host: {{ .Values.anm.ingressName }}.{{ .Values.global.domainName }}
+  - host: {{ .Values.anm.ingressName }}.{{ required "global.domainName is required." .Values.global.domainName }}
     http:
       paths:
       - path: /

--- a/APIM/Helmchart/amplify-apim-7.7/templates/anm/anm-ingress.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/templates/anm/anm-ingress.yaml
@@ -1,8 +1,12 @@
 {{- if ne .Values.global.platform "OPENSHIFT" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+apiVersion: networking.k8s.io/v1
+{{- else }}
 apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
-  name: gatewaymanager
+  name: {{ .Values.anm.name }}
   namespace: {{ .Release.Namespace }}
   annotations:
     {{- if .Values.global.managedIngress }}
@@ -17,7 +21,9 @@ metadata:
     {{- end }}
     {{- else }}
     kubernetes.io/ingress.class: nginx
+    {{- if .Values.global.issuedByLetsEncrypt }}
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    {{- end }}
     cert-manager.io/acme-challenge-type: http01
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/affinity: cookie
@@ -32,13 +38,23 @@ spec:
   tls:
   - hosts:
     - {{ .Values.anm.ingressName }}.{{ .Values.global.domainName }}
+    {{- if .Values.anm.certInSecret }}
     secretName: anm-ingress-cert
+    {{- end }}
   rules:
   - host: {{ .Values.anm.ingressName }}.{{ .Values.global.domainName }}
     http:
       paths:
-      - backend:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+          service:
+            name: {{ .Values.anm.name }}
+            port:
+              number: {{ .Values.anm.trafficPortUI }}
+          {{- else }}
           serviceName: {{ .Values.anm.name }}
           servicePort: {{ .Values.anm.trafficPortUI }}
-        path: /
+          {{- end }}
 {{- end }}

--- a/APIM/Helmchart/amplify-apim-7.7/templates/apiaga/apiaga-ingress.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/templates/apiaga/apiaga-ingress.yaml
@@ -37,7 +37,7 @@ metadata:
 spec:
   tls:
   - hosts:
-    - {{ .Values.apiaga.ingressName }}.{{ .Values.global.domainName }}
+    - {{ .Values.apiaga.ingressName }}.{{ required "global.domainName is required." .Values.global.domainName }}
     {{- if .Values.apiaga.certInSecret }}
     secretName: apimanager-ingress-cert
     {{- end }}

--- a/APIM/Helmchart/amplify-apim-7.7/templates/apiaga/apiaga-ingress.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/templates/apiaga/apiaga-ingress.yaml
@@ -1,9 +1,13 @@
 {{- if eq .Values.apiaga.enable true }}
 {{- if ne .Values.global.platform "OPENSHIFT" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+apiVersion: networking.k8s.io/v1
+{{- else }}
 apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
-  name: apimanager
+  name: {{ .Values.apiaga.name }}
   namespace: {{ .Release.Namespace }}
   annotations:
     {{- if .Values.global.managedIngress }}
@@ -18,12 +22,14 @@ metadata:
     {{- end }}
     {{- else }}
     kubernetes.io/ingress.class: nginx
+    {{- if .Values.global.issuedByLetsEncrypt }}
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    {{- end }}
     cert-manager.io/acme-challenge-type: http01
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/affinity: cookie
     nginx.ingress.kubernetes.io/affinity-mode: persistent
-    nginx.ingress.kubernetes.io/session-cookie-name: "API-Gateway-Manager-UI"
+    nginx.ingress.kubernetes.io/session-cookie-name: "API-Analytics-UI"
     nginx.ingress.kubernetes.io/session-cookie-expires: "172800"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
     nginx.ingress.kubernetes.io/session-cookie-change-on-failure: "true"
@@ -32,14 +38,24 @@ spec:
   tls:
   - hosts:
     - {{ .Values.apiaga.ingressName }}.{{ .Values.global.domainName }}
+    {{- if .Values.apiaga.certInSecret }}
     secretName: apimanager-ingress-cert
+    {{- end }}
   rules:
   - host: {{ .Values.apiaga.ingressName }}.{{ .Values.global.domainName }}
     http:
       paths:
-      - backend:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+          service:
+            name: {{ .Values.apiaga.name }}
+            port:
+              number: {{ .Values.apiaga.trafficPort }}
+          {{- else }}
           serviceName: {{ .Values.apiaga.name }}
           servicePort: {{ .Values.apiaga.trafficPort }}
-        path: /
+          {{- end }}
 {{- end }}
 {{- end }}

--- a/APIM/Helmchart/amplify-apim-7.7/templates/apimgr/apimgr-ingress.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/templates/apimgr/apimgr-ingress.yaml
@@ -1,5 +1,9 @@
 {{- if ne .Values.global.platform "OPENSHIFT" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+apiVersion: networking.k8s.io/v1
+{{- else }}
 apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: apimanager
@@ -17,12 +21,14 @@ metadata:
     {{- end }}
     {{- else }}
     kubernetes.io/ingress.class: nginx
+    {{- if .Values.global.issuedByLetsEncrypt }}
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    {{- end }}
     cert-manager.io/acme-challenge-type: http01
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/affinity: cookie
     nginx.ingress.kubernetes.io/affinity-mode: persistent
-    nginx.ingress.kubernetes.io/session-cookie-name: "API-Gateway-Manager-UI"
+    nginx.ingress.kubernetes.io/session-cookie-name: "API-Manager-UI"
     nginx.ingress.kubernetes.io/session-cookie-expires: "172800"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
     nginx.ingress.kubernetes.io/session-cookie-change-on-failure: "true"
@@ -31,13 +37,23 @@ spec:
   tls:
   - hosts:
     - {{ .Values.apimgr.ingressName }}.{{ .Values.global.domainName }}
+    {{- if .Values.apimgr.certInSecret }}
     secretName: apimanager-ingress-cert
+    {{- end }}
   rules:
   - host: {{ .Values.apimgr.ingressName }}.{{ .Values.global.domainName }}
     http:
       paths:
-      - backend:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+          service:
+            name: {{ .Values.apimgr.name }}
+            port:
+              number: {{ .Values.apimgr.trafficPort }}
+          {{- else }}
           serviceName: {{ .Values.apimgr.name }}
           servicePort: {{ .Values.apimgr.trafficPort }}
-        path: /
+          {{- end }}
 {{- end }}

--- a/APIM/Helmchart/amplify-apim-7.7/templates/apimgr/apimgr-ingress.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/templates/apimgr/apimgr-ingress.yaml
@@ -36,7 +36,7 @@ metadata:
 spec:
   tls:
   - hosts:
-    - {{ .Values.apimgr.ingressName }}.{{ .Values.global.domainName }}
+    - {{ .Values.apimgr.ingressName }}.{{ required "global.domainName is required." .Values.global.domainName }}
     {{- if .Values.apimgr.certInSecret }}
     secretName: apimanager-ingress-cert
     {{- end }}

--- a/APIM/Helmchart/amplify-apim-7.7/templates/apioauth/apioauth-ingress.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/templates/apioauth/apioauth-ingress.yaml
@@ -1,6 +1,10 @@
 {{- if eq .Values.oauth.enable true }}
 {{- if ne .Values.global.platform "OPENSHIFT" }}
-apiVersion: extensions/v1beta1
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+apiVersion: networking.k8s.io/v1
+{{- else }}
+apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: oauth
@@ -16,7 +20,9 @@ metadata:
     {{- end }}
     {{- else }}
     kubernetes.io/ingress.class: nginx
+    {{- if .Values.global.issuedByLetsEncrypt }}
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    {{- end }}
     cert-manager.io/acme-challenge-type: http01
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     {{- end }}
@@ -24,14 +30,24 @@ spec:
   tls:
   - hosts:
     - {{ .Values.oauth.ingressName }}.{{ .Values.global.domainName }}
+    {{- if .Values.oauth.certInSecret }}
     secretName: apioauth-ingress-cert
+    {{- end }}
   rules:
   - host: {{ .Values.oauth.ingressName }}.{{ .Values.global.domainName }}
     http:
       paths:
-      - backend:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+          service:
+            name: {{ .Values.oauth.name }}
+            port:
+              number: {{ .Values.oauth.trafficPort }}
+          {{- else }}
           serviceName: {{ .Values.oauth.name }}
           servicePort: {{ .Values.oauth.trafficPort }}
-        path: /
+          {{- end }}
 {{- end }}
 {{- end }}

--- a/APIM/Helmchart/amplify-apim-7.7/templates/apioauth/apioauth-ingress.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/templates/apioauth/apioauth-ingress.yaml
@@ -29,7 +29,7 @@ metadata:
 spec:
   tls:
   - hosts:
-    - {{ .Values.oauth.ingressName }}.{{ .Values.global.domainName }}
+    - {{ .Values.oauth.ingressName }}.{{ required "global.domainName is required." .Values.global.domainName }}
     {{- if .Values.oauth.certInSecret }}
     secretName: apioauth-ingress-cert
     {{- end }}

--- a/APIM/Helmchart/amplify-apim-7.7/templates/apiportal/apiportal-ingress.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/templates/apiportal/apiportal-ingress.yaml
@@ -34,7 +34,7 @@ metadata:
 spec:
   tls:
   - hosts:
-    - {{ .Values.apiportal.ingressName }}.{{ .Values.global.domainName }}
+    - {{ .Values.apiportal.ingressName }}.{{ required "global.domainName is required." .Values.global.domainName }}
     {{- if .Values.apiportal.certInSecret }}
     secretName: tls-secret-portal
     {{- end }}

--- a/APIM/Helmchart/amplify-apim-7.7/templates/apiportal/apiportal-ingress.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/templates/apiportal/apiportal-ingress.yaml
@@ -1,6 +1,10 @@
 {{- if eq .Values.apiportal.enable true }}
 {{- if ne .Values.global.platform "OPENSHIFT" }}
-apiVersion: extensions/v1beta1
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+apiVersion: networking.k8s.io/v1
+{{- else }}
+apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ .Values.apiportal.name }}
@@ -15,7 +19,9 @@ metadata:
     {{- end }}
     {{- else }}
     kubernetes.io/ingress.class: nginx
+    {{- if .Values.global.issuedByLetsEncrypt }}
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    {{- end }}
     cert-manager.io/acme-challenge-type: http01
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     nginx.ingress.kubernetes.io/affinity: "cookie"
@@ -29,14 +35,24 @@ spec:
   tls:
   - hosts:
     - {{ .Values.apiportal.ingressName }}.{{ .Values.global.domainName }}
+    {{- if .Values.apiportal.certInSecret }}
     secretName: tls-secret-portal
+    {{- end }}
   rules:
   - host: {{ .Values.apiportal.ingressName }}.{{ .Values.global.domainName }}
     http:
       paths:
-      - backend:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+          service:
+            name: {{ .Values.apiportal.name }}
+            port:
+              number: {{ .Values.apiportal.trafficPort }}
+          {{- else }}
           serviceName: {{ .Values.apiportal.name }}
           servicePort: {{ .Values.apiportal.trafficPort }}
-        path: /
+          {{- end }}
 {{- end }}
 {{- end }}

--- a/APIM/Helmchart/amplify-apim-7.7/templates/apitraffic/apitraffic-ingress.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/templates/apitraffic/apitraffic-ingress.yaml
@@ -29,7 +29,7 @@ metadata:
 spec:
   tls:
   - hosts:
-    - {{ .Values.apitraffic.ingressName }}.{{ .Values.global.domainName }}
+    - {{ .Values.apitraffic.ingressName }}.{{ required "global.domainName is required." .Values.global.domainName }}
     {{- if .Values.apitraffic.certInSecret }}
     secretName: apitraffic-ingress-cert
     {{- end }}

--- a/APIM/Helmchart/amplify-apim-7.7/templates/apitraffic/apitraffic-ingress.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/templates/apitraffic/apitraffic-ingress.yaml
@@ -1,5 +1,9 @@
 {{- if ne .Values.global.platform "OPENSHIFT" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+apiVersion: networking.k8s.io/v1
+{{- else }}
 apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: traffic
@@ -15,7 +19,9 @@ metadata:
     {{- end }}
     {{- else }}
     kubernetes.io/ingress.class: nginx
+    {{- if .Values.global.issuedByLetsEncrypt }}
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    {{- end }}
     cert-manager.io/acme-challenge-type: http01
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     nginx.ingress.kubernetes.io/affinity-mode: "persistent"
@@ -24,13 +30,23 @@ spec:
   tls:
   - hosts:
     - {{ .Values.apitraffic.ingressName }}.{{ .Values.global.domainName }}
+    {{- if .Values.apitraffic.certInSecret }}
     secretName: apitraffic-ingress-cert
+    {{- end }}
   rules:
   - host: {{ .Values.apitraffic.ingressName }}.{{ .Values.global.domainName }}
     http:
       paths:
-      - backend:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+          service:
+            name: {{ .Values.apitraffic.name }}
+            port:
+              number: {{ .Values.apitraffic.portManager }}
+          {{- else }}
           serviceName: {{ .Values.apitraffic.name }}
           servicePort: {{ .Values.apitraffic.portManager }}
-        path: /
+          {{- end }}
 {{- end }}

--- a/APIM/Helmchart/amplify-apim-7.7/values.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/values.yaml
@@ -15,7 +15,7 @@ global:
    initImageTag: "busybox:1.33"
    updateStrategy: "RollingUpdate"
    editor: "Axway"
-   apimVersion: "7.7-20210130"
+   apimVersion: "7.7-20210330"
    domainName: ""
    dockerRegistry:
       secret: "registry-secret"
@@ -32,10 +32,11 @@ global:
       scrwo:
       scrwm:
    createSecrets: true
+   issuedByLetsEncrypt: false
 
 anm:
    name: anm
-   buildTag: "20210130"
+   buildTag: "20210330"
    imageName: "apim-anm-7.7"
    ingressName: "anm"
    replicaCount: 1
@@ -48,10 +49,11 @@ anm:
    emt_topology_log_enabled: "true"
    emt_topology_ttl: 10
    emt_trace_level: "INFO"
+   certInSecret: false
 
 apimgr:
    name: apimgr
-   buildTag: "20210130"
+   buildTag: "20210330"
    imageName: "apim-gtw-7.7"
    ingressName: "api-mgr"
    replicaCount: 1
@@ -63,10 +65,11 @@ apimgr:
    emt_topology_log_enabled: "true"
    emt_topology_ttl: 10
    emt_trace_level: "INFO"
+   certInSecret: false
 
 apitraffic:
    name: traffic
-   buildTag: "20210130"
+   buildTag: "20210330"
    imageName: "apim-gtw-7.7"
    ingressName: "api"
    portManager: 8065
@@ -91,11 +94,12 @@ apitraffic:
       quota: 1
    volumes:
       accessModes: ReadWriteOnce
+   certInSecret: false
 
 apiportal:
    enable: false
    name: "api-portal"
-   buildTag: "7.7-20210130"
+   buildTag: "7.7-20210330"
    imageName: "apim-ptl"
    ingressName: "portal"
    trafficPort: 443
@@ -103,11 +107,12 @@ apiportal:
    share:
       secret: "apiportal-secret-name"
       name: "apiportal-volume-rwm-name"
+   certInSecret: false
 
 apiaga:
-   enable: true
+   enable: false
    name: apiaga
-   buildTag: "20210130"
+   buildTag: "20210330"
    imageName: "apim-aga-7.7"
    ingressName: "api-aga"
    replicaCount: 1
@@ -118,6 +123,7 @@ apiaga:
    emt_heap_size_mb: "1024"
    emt_topology_ttl: 10
    emt_trace_level: "INFO"
+   certInSecret: false
 
 mysqlAnalytics:
    enable: true
@@ -172,3 +178,4 @@ oauth:
    name: "oauth"
    ingressName: "oauth"
    trafficPort: 8089
+   certInSecret: false


### PR DESCRIPTION
- Made Ingress compatible with Kube 1.19.
- Included optionality for certs created by Let's Encrypt.
- Updated image to 20210330.
- Made Analytics disabled by default, otherwise it also requires MySQL and then it won't ever work until MySQL is enabled (ANM still shows error connecting to metrics DB, but it is able to start up).