### PR TITLE
- Fixing a license typo (licence, or apim-config).

### DIFF
--- a/APIM/Helmchart/amplify-apim-7.7/templates/anm/anm-deployment.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/templates/anm/anm-deployment.yaml
@@ -68,15 +68,17 @@ spec:
         ports:
         - containerPort: {{ .Values.anm.trafficPort }}
           protocol: TCP
+        {{- if ne .Values.anm.trafficPort .Values.anm.trafficPortUI }}
         - containerPort: {{ .Values.anm.trafficPortUI }}
           protocol: TCP
+        {{- end }}
         resources:
           limits:
             memory: "2048Mi"
             cpu: "1000m"
           requests:
             memory: "1Gi"
-            cpu: "250m" 
+            cpu: "250m"
         livenessProbe:
           httpGet:
             httpHeaders:
@@ -106,6 +108,14 @@ spec:
         volumeMounts:
         - name: events
           mountPath: {{ .Values.apitraffic.share.path | quote }}
+        - name: config-jvmxml
+          mountPath: "/opt/Axway/apigateway/conf/jvm.xml"
+          subPath: jvm.xml
+        {{- if eq .Values.global.enableDynamicLicense true }}
+        - name: config-license
+          mountPath: "/opt/Axway/apigateway/conf/licenses/lic.lic"
+          subPath: license
+        {{- end }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       imagePullSecrets:
@@ -129,5 +139,18 @@ spec:
       - name: events
         persistentVolumeClaim:
           claimName: apigw-events
+      - name: config-jvmxml
+        configMap:
+          name: jvmxml
+          defaultMode: 256
+          items:
+            - key: jvm
+              mode: 256
+              path: jvm.xml
+      {{- if eq .Values.global.enableDynamicLicense true }}
+      - name: config-license
+        configMap:
+          name: license
+      {{- end }}
       terminationGracePeriodSeconds: 100
 status: {}

--- a/APIM/Helmchart/amplify-apim-7.7/templates/anm/anm-service.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/templates/anm/anm-service.yaml
@@ -12,10 +12,12 @@ spec:
     port: {{ .Values.anm.trafficPort }} 
     targetPort: {{ .Values.anm.trafficPort }}
     protocol: TCP
+  {{- if ne .Values.anm.trafficPort .Values.anm.trafficPortUI }}
   - name: gatewaymanagerui
     port: {{ .Values.anm.trafficPortUI }}
     targetPort: {{ .Values.anm.trafficPortUI }}
     protocol: TCP
+  {{- end }}
   selector:
     app: {{ .Values.anm.name | quote }}
   sessionAffinity: ClientIP

--- a/APIM/Helmchart/amplify-apim-7.7/templates/apiaga/apiaga-deployment.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/templates/apiaga/apiaga-deployment.yaml
@@ -2,6 +2,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    apigw.version: {{ .Values.global.apimVersion | quote }}
+    apigw.editor: {{ .Values.global.editor | quote }}
   labels:
     app: {{ .Values.apiaga.name | quote }}
   name: {{ .Values.apiaga.name | quote }}
@@ -12,7 +15,7 @@ spec:
     matchLabels:
       app: {{ .Values.apiaga.name | quote }}
   strategy:
-    type: RollingUpdate
+    type: {{ .Values.global.updateStrategy }}
   template:
     metadata:
       labels:
@@ -26,7 +29,7 @@ spec:
             - matchExpressions:
               - key: agentpool
                 operator: In
-                values: 
+                values:
                 - {{ .Values.global.nodeAffinity.apimName }}
       {{- end }}
       containers:
@@ -60,33 +63,20 @@ spec:
           protocol: TCP
         resources: {}
         readinessProbe:
-          httpGet:
-            httpHeaders:
-            - name: k8sprobe
-              value: readiness.{{ .Values.apiaga.name }}
-            path: /healthcheck
+          tcpSocket:
             port: {{ .Values.apiaga.trafficPort }}
-            scheme: HTTPS
           initialDelaySeconds: 50
           periodSeconds: 15
           failureThreshold: 10
         livenessProbe:
-          httpGet:
-            httpHeaders:
-            - name: k8sprobe
-              value: liveness.{{ .Values.apiaga.name }}
-            path: /healthcheck
+          tcpSocket:
             port: {{ .Values.apiaga.trafficPort }}
-            scheme: HTTPS
           initialDelaySeconds: 30
           periodSeconds: 30
           failureThreshold: 5
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - name: config-jvmxml
-          mountPath: "/opt/Axway/analytics/conf/jvm.xml"
-          subPath: jvm.xml
         {{- if eq .Values.global.enableDynamicLicense true }}
         - name: config-license
           mountPath: "/opt/Axway/analytics/conf/licenses/lic.lic"
@@ -101,7 +91,8 @@ spec:
         image: {{ .Values.global.initImageTag }}
         command: ['sh', '-c', 'until nc -w 3 -v {{ .Values.mysqlAnalytics.name }} 3306; do echo waiting for mysql; sleep 2; done;']
       imagePullSecrets:
-      - name: {{ .Values.global.dockerRegistry.secret }}      
+      - name: {{ .Values.global.dockerRegistry.secret }}
+      dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
       {{- if ne .Values.global.platform "OPENSHIFT" }}
@@ -111,14 +102,7 @@ spec:
       {{- end }}
       terminationGracePeriodSeconds: 101
       terminationGracePeriodSeconds: 100
-      - name: config-jvmxml
-        configMap:
-          name: jvmxml
-          defaultMode: 256
-          items:
-            - key: jvm
-              mode: 256
-              path: jvm.xml
+      volumes:
       {{- if eq .Values.global.enableDynamicLicense true }}
       - name: config-license
         configMap:

--- a/APIM/Helmchart/amplify-apim-7.7/templates/apiaga/apiaga-deployment.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/templates/apiaga/apiaga-deployment.yaml
@@ -83,6 +83,10 @@ spec:
           failureThreshold: 5
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        volumeMounts:
+        - name: config-jvmxml
+          mountPath: "/opt/Axway/analytics/conf/jvm.xml"
+          subPath: jvm.xml
         {{- if eq .Values.global.enableDynamicLicense true }}
         - name: config-license
           mountPath: "/opt/Axway/analytics/conf/licenses/lic.lic"
@@ -107,9 +111,17 @@ spec:
       {{- end }}
       terminationGracePeriodSeconds: 101
       terminationGracePeriodSeconds: 100
+      - name: config-jvmxml
+        configMap:
+          name: jvmxml
+          defaultMode: 256
+          items:
+            - key: jvm
+              mode: 256
+              path: jvm.xml
       {{- if eq .Values.global.enableDynamicLicense true }}
       - name: config-license
         configMap:
-          name: apim-config
+          name: license
       {{- end }}
 {{- end }}

--- a/APIM/Helmchart/amplify-apim-7.7/templates/apimgr/apimgr-deployment.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/templates/apimgr/apimgr-deployment.yaml
@@ -25,7 +25,7 @@ spec:
             - matchExpressions:
               - key: agentpool
                 operator: In
-                values: 
+                values:
                 - {{ .Values.global.nodeAffinity.apimName }}
       {{- end }}
       containers:
@@ -112,6 +112,9 @@ spec:
         volumeMounts:
         - mountPath: {{ .Values.apitraffic.share.path | quote }}
           name: events
+        - name: config-jvmxml
+          mountPath: "/opt/Axway/apigateway/conf/jvm.xml"
+          subPath: jvm.xml
         {{- if eq .Values.global.enableDynamicLicense true }}
         - name: config-license
           mountPath: "/opt/Axway/apigateway/conf/licenses/lic.lic"
@@ -147,8 +150,16 @@ spec:
       - name: events
         persistentVolumeClaim:
           claimName: apigw-events
+      - name: config-jvmxml
+        configMap:
+          name: jvmxml
+          defaultMode: 256
+          items:
+            - key: jvm
+              mode: 256
+              path: jvm.xml
       {{- if eq .Values.global.enableDynamicLicense true }}
       - name: config-license
         configMap:
-          name: licence
+          name: license
       {{- end }}

--- a/APIM/Helmchart/amplify-apim-7.7/templates/apimgr/apimgr-deployment.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/templates/apimgr/apimgr-deployment.yaml
@@ -51,6 +51,10 @@ spec:
             secretKeyRef:
               name: apim-password
               key: dbcass
+        - name: cassandraconsistency_writelevel
+          value: {{ .Values.cassandra.consistency_level }}
+        - name: cassandraconsistency_readlevel
+          value: {{ .Values.cassandra.consistency_level }}
         - name: EMT_ANM_HOSTS
           value: {{ .Values.anm.name }}:{{ .Values.anm.trafficPort }}
         - name: EMT_TOPOLOGY_LOG_ENABLED
@@ -67,6 +71,7 @@ spec:
           value: "{{ .Values.apimgr.logTraceJSONtoSTDOUT }}"
         - name: APIGW_LOG_OPENTRAFFIC_OUTPUT
           value: "{{ .Values.apimgr.logOpenTrafficOutput }}"
+        {{- if eq .Values.mysqlAnalytics.enable true }}
         - name: METRICS_DB_URL
           value: jdbc:mysql://{{ .Values.mysqlAnalytics.name }}:{{ .Values.mysqlAnalytics.port }}/{{ .Values.mysqlAnalytics.dbName }}?useSSL={{ .Values.mysqlAnalytics.ssl }}
         - name: METRICS_DB_USERNAME
@@ -76,6 +81,7 @@ spec:
             secretKeyRef:
               name: apim-password
               key: dbmysqlanalytics
+        {{- end }}
         - name: EMT_DEPLOYMENT_ENABLED
           value: "{{ .Values.global.emtDeployment }}"
         image: {{ .Values.global.dockerRegistry.url }}/{{ .Values.apimgr.imageName }}:{{ .Values.apimgr.buildTag }}

--- a/APIM/Helmchart/amplify-apim-7.7/templates/apimgr/apimgr-ingress.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/templates/apimgr/apimgr-ingress.yaml
@@ -21,6 +21,7 @@ metadata:
     {{- end }}
     {{- else }}
     kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.global.bodySize | quote }}
     {{- if .Values.global.issuedByLetsEncrypt }}
     cert-manager.io/cluster-issuer: letsencrypt-prod
     {{- end }}

--- a/APIM/Helmchart/amplify-apim-7.7/templates/apiportal/apiportal-deployment.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/templates/apiportal/apiportal-deployment.yaml
@@ -25,7 +25,7 @@ spec:
             - matchExpressions:
               - key: agentpool
                 operator: In
-                values: 
+                values:
                 - {{ .Values.global.nodeAffinity.apimName }}
         {{- end }}
         podAntiAffinity:
@@ -52,14 +52,14 @@ spec:
             secretKeyRef:
               name: apim-password
               key: dbmysqlroot
-        - name: MYSQL_USERNAME
+        - name: MYSQL_USER
           value: {{ .Values.mysqlPortal.adminUser }}
         - name: MYSQL_PASSWORD
           valueFrom:
             secretKeyRef:
               name: apim-password
               key: dbmysqlportal
-        - name: MYSQL_DBNAME
+        - name: MYSQL_DATABASE
           value: {{ .Values.mysqlPortal.dbName }}
         - name: APIMANAGER_HOST
           value: {{ .Values.apimgr.name }}
@@ -73,15 +73,15 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 443
-            scheme: HTTPS
+            port: {{ .Values.apiportal.trafficPort }}
+            scheme: {{ .Values.apiportal.scheme }}
           initialDelaySeconds: 10
           periodSeconds: 5
         livenessProbe:
           httpGet:
             path: /
-            port: 443
-            scheme: HTTPS
+            port: {{ .Values.apiportal.trafficPort }}
+            scheme: {{ .Values.apiportal.scheme }}
           initialDelaySeconds: 30
           periodSeconds: 5
         ports:
@@ -103,8 +103,8 @@ spec:
       schedulerName: default-scheduler
       {{- if ne .Values.global.platform "OPENSHIFT" }}
       securityContext:
-        runAsUser: 1000
-        fsGroup: 1000
+        runAsUser: {{ .Values.apiportal.runAsUser }}
+        fsGroup: {{ .Values.apiportal.runAsUser }}
       {{- end }}
   strategy:
     type: {{ .Values.global.updateStrategy }}

--- a/APIM/Helmchart/amplify-apim-7.7/templates/apiportal/apiportal-ingress.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/templates/apiportal/apiportal-ingress.yaml
@@ -23,10 +23,10 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     {{- end }}
     cert-manager.io/acme-challenge-type: http01
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/backend-protocol: {{ .Values.apiportal.scheme | quote }}
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/affinity-mode: "persistent"
-    nginx.ingress.kubernetes.io/session-cookie-name: "API-Gateway-Manager-UI"
+    nginx.ingress.kubernetes.io/session-cookie-name: "API-Portal"
     nginx.ingress.kubernetes.io/session-cookie-expires: "172800"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
     nginx.ingress.kubernetes.io/session-cookie-change-on-failure: "true"

--- a/APIM/Helmchart/amplify-apim-7.7/templates/apitraffic/apitraffic-deployment.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/templates/apitraffic/apitraffic-deployment.yaml
@@ -95,6 +95,9 @@ spec:
         volumeMounts:
         - mountPath: {{ .Values.apitraffic.share.path | quote }}
           name: events
+        - name: config-jvmxml
+          mountPath: "/opt/Axway/apigateway/conf/jvm.xml"
+          subPath: jvm.xml
         {{- if eq .Values.global.enableDynamicLicense true }}
         - name: config-license
           mountPath: "/opt/Axway/apigateway/conf/licenses/lic.lic"
@@ -124,8 +127,8 @@ spec:
             - name: k8sprobe
               value: readiness.{{ .Values.apitraffic.name }}
             path: /healthcheck
-            port: {{ .Values.apitraffic.portManager }}
-            scheme: HTTPS
+            port: .Values.apitraffic.portProbe
+            scheme: .Values.apitraffic.schemeProbe
           initialDelaySeconds: 40
           periodSeconds: 30
           failureThreshold: 5
@@ -135,8 +138,8 @@ spec:
             - name: k8sprobe
               value: liveness.{{ .Values.apitraffic.name }}
             path: /healthcheck
-            port: {{ .Values.apitraffic.portManager }}
-            scheme: HTTPS
+            port: .Values.apitraffic.portProbe
+            scheme: .Values.apitraffic.schemeProbe
           initialDelaySeconds: 30
           periodSeconds: 30
           failureThreshold: 5
@@ -179,6 +182,14 @@ spec:
       - name: events
         persistentVolumeClaim:
           claimName: apigw-events
+      - name: config-jvmxml
+        configMap:
+          name: jvmxml
+          defaultMode: 256
+          items:
+            - key: jvm
+              mode: 256
+              path: jvm.xml
       {{- if eq .Values.global.enableDynamicLicense true }}
       - name: config-license
         configMap:

--- a/APIM/Helmchart/amplify-apim-7.7/templates/apitraffic/apitraffic-deployment.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/templates/apitraffic/apitraffic-deployment.yaml
@@ -127,8 +127,8 @@ spec:
             - name: k8sprobe
               value: readiness.{{ .Values.apitraffic.name }}
             path: /healthcheck
-            port: .Values.apitraffic.portProbe
-            scheme: .Values.apitraffic.schemeProbe
+            port: {{ .Values.apitraffic.portProbe }}
+            scheme: {{ .Values.apitraffic.schemeProbe }}
           initialDelaySeconds: 40
           periodSeconds: 30
           failureThreshold: 5
@@ -138,8 +138,8 @@ spec:
             - name: k8sprobe
               value: liveness.{{ .Values.apitraffic.name }}
             path: /healthcheck
-            port: .Values.apitraffic.portProbe
-            scheme: .Values.apitraffic.schemeProbe
+            port: {{ .Values.apitraffic.portProbe }}
+            scheme: {{ .Values.apitraffic.schemeProbe }}
           initialDelaySeconds: 30
           periodSeconds: 30
           failureThreshold: 5

--- a/APIM/Helmchart/amplify-apim-7.7/templates/apitraffic/apitraffic-deployment.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/templates/apitraffic/apitraffic-deployment.yaml
@@ -80,6 +80,7 @@ spec:
           value: "{{ .Values.apitraffic.logOpenTrafficOutput }}"
         - name: EMT_DEPLOYMENT_ENABLED
           value: "{{ .Values.global.emtDeployment }}"
+        {{- if eq .Values.mysqlAnalytics.enable true }}
         - name: METRICS_DB_URL
           value: jdbc:mysql://{{ .Values.mysqlAnalytics.name }}:{{ .Values.mysqlAnalytics.port }}/{{ .Values.mysqlAnalytics.dbName }}?useSSL={{ .Values.mysqlAnalytics.ssl }}
         - name: METRICS_DB_USERNAME
@@ -89,6 +90,7 @@ spec:
             secretKeyRef:
               name: apim-password
               key: dbmysqlanalytics
+        {{- end }}
         image: {{ .Values.global.dockerRegistry.url }}/{{ .Values.apitraffic.imageName }}:{{ .Values.apitraffic.buildTag }} 
         imagePullPolicy: {{ .Values.global.pullPolicy }} 
         name: {{ .Values.apitraffic.name }}

--- a/APIM/Helmchart/amplify-apim-7.7/templates/common/jvmxml-configmap.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/templates/common/jvmxml-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+   name: jvmxml
+   namespace: {{ .Release.Namespace | quote }}
+data:
+   jvm: |
+    <ConfigurationFragment>
+    <VMArg name="-Ddont.expect.100.continue=true"/>
+    <VMArg name="-Dio.swagger.parser.util.RemoteUrl.trustAll=true"/>
+    <VMArg name="-Dio.swagger.v3.parser.util.RemoteUrl.trustAll=true"/>
+    </ConfigurationFragment>

--- a/APIM/Helmchart/amplify-apim-7.7/templates/common/license-configmap.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/templates/common/license-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-   name: licence
+   name: license
    namespace: {{ .Release.Namespace | quote }}
 data:
    license: |

--- a/APIM/Helmchart/amplify-apim-7.7/values.local.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/values.local.yaml
@@ -20,34 +20,43 @@ global:
 
 anm:
    ingressName: "admin"
-   buildTag: "7.7.21.05"
+   buildTag: "7.7.20210530"
    imageName: "anm"
    trafficPortUI: 8090
+   logTraceJSONtoSTDOUT: "true"
+   emt_heap_size_mb: "2048"
 
 apimgr:
    ingressName: "apimanager"
-   buildTag: "7.7.21.05"
+   buildTag: "7.7.20210530"
    imageName: "mngr"
+   logTraceJSONtoSTDOUT: "true"
 
 apitraffic:
-   buildTag: "7.7.21.05"
+   buildTag: "7.7.20210530"
    imageName: "mngr"
    portProbe: 8080
    schemeProbe: "HTTP"
 
 apiaga:
-   buildTag: "7.7.21.05"
+   enable: true
+   buildTag: "7.7.20210530"
    imageName: "ana"
 
 cassandra:
    external: true
    # Change this IP to the Cassandra's cluster IPs.
-   host1: "10.42.12.227"
-   host2: "10.42.12.227"
-   host3: "10.42.12.227"
+   host1: "10.42.12.229"
+   host2: "10.42.12.229"
+   host3: "10.42.12.229"
    # That is the default domain for Cassandra on the default namespace.
    # Change it to your specific case if necessary.
    domain: ".default.svc.cluster.local"
 
-mysqlAnalytics:
-   enable: false
+apiportal:
+   enable: true
+   buildTag: "7.7.20210530"
+   imageName: "apiportal"
+   trafficPort: 80
+   scheme: HTTP
+   runAsUser: 1048

--- a/APIM/Helmchart/amplify-apim-7.7/values.local.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/values.local.yaml
@@ -8,12 +8,36 @@ global:
    #Annotation
 
    # That is just a dummy domain.
-   domainName: "local.io"
+   domainName: "axway.io"
    # To have the local-path storage class, remember to run:
    # kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
    customStorageClass:
       scrwo: local-path
       scrwm: local-path
+   enableDynamicLicense: true
+   dockerRegistry:
+      url: lacg
+
+anm:
+   ingressName: "admin"
+   buildTag: "7.7.21.05"
+   imageName: "anm"
+   trafficPortUI: 8090
+
+apimgr:
+   ingressName: "apimanager"
+   buildTag: "7.7.21.05"
+   imageName: "mngr"
+
+apitraffic:
+   buildTag: "7.7.21.05"
+   imageName: "mngr"
+   portProbe: 8080
+   schemeProbe: "HTTP"
+
+apiaga:
+   buildTag: "7.7.21.05"
+   imageName: "ana"
 
 cassandra:
    external: true

--- a/APIM/Helmchart/amplify-apim-7.7/values.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/values.yaml
@@ -95,6 +95,8 @@ apitraffic:
    volumes:
       accessModes: ReadWriteOnce
    certInSecret: false
+   portProbe: 8065
+   schemeProbe: "HTTPS"
 
 apiportal:
    enable: false

--- a/APIM/Helmchart/amplify-apim-7.7/values.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/values.yaml
@@ -33,6 +33,7 @@ global:
       scrwm:
    createSecrets: true
    issuedByLetsEncrypt: false
+   bodySize: 10m
 
 anm:
    name: anm
@@ -103,20 +104,22 @@ apiportal:
    name: "api-portal"
    buildTag: "7.7-20210330"
    imageName: "apim-ptl"
-   ingressName: "portal"
+   ingressName: "apiportal"
    trafficPort: 443
+   scheme: HTTPS
    replicaCount: 1
    share:
       secret: "apiportal-secret-name"
       name: "apiportal-volume-rwm-name"
    certInSecret: false
+   runAsUser: 1000
 
 apiaga:
    enable: false
    name: apiaga
    buildTag: "20210330"
    imageName: "apim-aga-7.7"
-   ingressName: "api-aga"
+   ingressName: "analytics"
    replicaCount: 1
    trafficPort: 8040
    logTraceToFile: "true"
@@ -161,9 +164,9 @@ cassandra:
    host2: "ip_host2"
    host3: "ip_host3"
    domain: ""
+   consistency_level: "LOCAL_QUORUM"
 
 mysqlPortal:
-   enable: false
    external: true
    name: "mysql-portal"
    imageName: "mysql"


### PR DESCRIPTION
- Adding jvm.xml config map.
- Adding port probe and scheme probe allowing to change the readiness and liveness probes to check on different ports then the portManager and HTTPS (on the default image, the 8065 does not have healthcheck/healthchecklb and HTTPS scheme).
- There is no new ANM listener for UI on the standard ANM image. This requires a new image with changes on the ANM by default, so I made it possible that in case the UI port and the non-UI port are the same, we won't need a new service/traffic port created.

P.S.: Although the ANM does not need the license config map, there was an error on the logs complaining about it. So I just included to get rid of it. Also, the two swagger parsers includes on the JVM are related to an R&D suggestion to improve the imports of OAS3 swaggers. ANM does not need it, but as the 100 continue would help in case of HTTP 1.1, I included as well...