### PR TITLE
Updates for supporting Portal

### DIFF
--- a/APIM/Helmchart/amplify-apim-7.7/templates/apiportal/apiportal-deployment.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/templates/apiportal/apiportal-deployment.yaml
@@ -43,6 +43,8 @@ spec:
         - name: {{ .Values.global.dockerRegistry.secret }}
       containers:
       - env:
+        - name: APACHE_SSL_ON
+          value: {{ .Values.apiportal.ssl | quote }}
         - name: MYSQL_HOST
           value: {{ .Values.mysqlPortal.name | quote }}
         - name: MYSQL_PORT
@@ -61,15 +63,21 @@ spec:
               key: dbmysqlportal
         - name: MYSQL_DATABASE
           value: {{ .Values.mysqlPortal.dbName }}
+        - name: APIMANAGER_CONFIGURED
+          value: {{ .Values.apiportal.configureManager | quote }}
         - name: APIMANAGER_HOST
           value: {{ .Values.apimgr.name }}
         - name: APIMANAGER_PORT
           value: {{ .Values.apimgr.trafficPort | quote }}
-        - name: APIMANAGER_PUBLIC_NAME
+        - name: APIMANAGER_NAME
           value: {{ .Values.apimgr.name }}
         name: {{ .Values.apiportal.name }}
         image: {{ .Values.global.dockerRegistry.url }}/{{ .Values.apiportal.imageName }}:{{ .Values.apiportal.buildTag }}
         imagePullPolicy: {{ .Values.global.pullPolicy }}
+        volumeMounts:
+        - name: apache-store
+          mountPath: "/opt/axway/apiportal/certs/apache/"
+          readOnly: true
         readinessProbe:
           httpGet:
             path: /
@@ -106,6 +114,10 @@ spec:
         runAsUser: {{ .Values.apiportal.runAsUser }}
         fsGroup: {{ .Values.apiportal.runAsUser }}
       {{- end }}
+      volumes:
+      - name: apache-store
+        configMap:
+          name: apache-store
   strategy:
     type: {{ .Values.global.updateStrategy }}
 status: {}

--- a/APIM/Helmchart/amplify-apim-7.7/templates/common/apache-configmap.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/templates/common/apache-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: apache-store
+  namespace: {{ .Release.Namespace | quote }}
+data:
+  apache.crt: |
+    -----BEGIN CERTIFICATE-----
+    -----END CERTIFICATE-----
+  apache.key: |
+    -----BEGIN PRIVATE KEY-----
+    -----END PRIVATE KEY-----

--- a/APIM/Helmchart/amplify-apim-7.7/values.yaml
+++ b/APIM/Helmchart/amplify-apim-7.7/values.yaml
@@ -107,12 +107,14 @@ apiportal:
    ingressName: "apiportal"
    trafficPort: 443
    scheme: HTTPS
+   ssl: 1
+   configureManager: 1
    replicaCount: 1
    share:
       secret: "apiportal-secret-name"
       name: "apiportal-volume-rwm-name"
    certInSecret: false
-   runAsUser: 1000
+   runAsUser: 1048
 
 apiaga:
    enable: false

--- a/APIM/Helmchart/helmforAPIM.md
+++ b/APIM/Helmchart/helmforAPIM.md
@@ -32,6 +32,8 @@ The following tables lists the mandatory parameters of the AMPLIFY API Managemen
 | apitraffic.buildTag | Docker image tag of API Gateway component | - |
 | apitraffic.imageName | Docker image name of API Gateway component | - |
 | apitraffic.ingressName |  | - |
+| apiportal.imageName | Docker image name for API Portal component | |
+| apiportal.buildTag | Docker image tag for API Portal component | |
 | cassandra.adminPasswd | Password of cassandra User | changeme |
 | mysqlAnalytics.adminPasswd | Password of Mysql user | changeme |
 | mysqlAnalytics.rootPasswd | Password of Mysql root user | changeme |
@@ -59,6 +61,12 @@ The following tables lists the parameters and their default values to configure 
 | apitraffic.emt_heap_size_mb | Specifies the initial and maximum Java heap size | 1512 |
 | oauth.enable | Enable oauth feature | false |
 | oauth.ingressName | Url to access to the oauth API | - |
+
+You will also need to include a certificate and key for configuring Apache HTTP server in your API Portal pod. These certificate and key should be included in the configmap yaml file at:
+
+```bash
+Cloud-Automation/APIM/Helmchart/amplify-apim-7.7/templates/common/apache-configmap.yaml
+```
 
 ## Optional Configuration
 The following tables lists the optional parameters of the AMPLIFY API Management Helm chart and their default values.


### PR DESCRIPTION
Added a configmap to set a  certificate and key for Apache HTTP server inside a Portal container. Add a couple of additional supported parameters for API Portal in API Portal deployment.
These updates were tested with the latest APIM release, 7.7.20210530, in two different deployment targets: Docker Desktop and OpenShift